### PR TITLE
Convert Dates To ISO Format For JSON

### DIFF
--- a/backend/job_searcher.py
+++ b/backend/job_searcher.py
@@ -77,6 +77,11 @@ def mongo_query_args(args: dict) -> dict:
     return query_args
 
 def sanitize_mongo_bson(inputMongo: dict) -> dict:
+    for key in inputMongo.keys():
+        item = inputMongo[key]
+        if hasattr(item, 'isoformat'):
+            inputMongo[key] = item.isoformat()
+    
     return json.loads(json_util.dumps(inputMongo))
 
 def build_location_query(args: dict) -> dict:


### PR DESCRIPTION
Dates were being exported as Python datetime objects instead of something readable by JS. Now they should be ISO Date Strings that JS should be equipped to use. 